### PR TITLE
Mobile viewport

### DIFF
--- a/development.html
+++ b/development.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>can-connect-signalr-test-app</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 </head>
 <body>
   <script src="node_modules/steal/steal.js"></script>

--- a/production.html
+++ b/production.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>can-connect-signalr-test-app</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 </head>
 <body>
   <script src="./dist/steal.production.js"></script>


### PR DESCRIPTION
Adds `<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">` to the template so that it scales correctly on mobile. 

@moschel can we merge and deploy this? That way I can make the gif using iOS simulator. 